### PR TITLE
Add Taxa level endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,80 @@ response = client.use_and_trade.list
 response
 ```
 
+## Taxa
+
+### Kingdom
+
+To retrieve a list of all Kingdoms
+```
+response = client.taxa.kingdom.list
+response
+```
+
+To retrieve a list of assessments for a given Kingdom
+```
+response = client.taxa.kingdom.all('FUNGI')
+response
+```
+
+
+### Phylum
+
+To retrieve a list of all Phyla
+```
+response = client.taxa.phylum.list
+response
+```
+
+To retrieve a list of assessments for a given Phylum
+```
+response = client.taxa.phylum.all('ANNELIDA')
+response
+```
+
+### Class
+
+To retrieve a list of all Classes
+```
+response = client.taxa.class.list
+response
+```
+
+To retrieve a list of assessments for a given Class
+```
+response = client.taxa.class.all('ACTINOPTERYGII')
+response
+```
+
+## Order
+
+To retrieve a list of all Orders
+```
+response = client.taxa.order.list
+response
+```
+
+To retrieve a list of assessments for a given Order
+```
+response = client.taxa.order.all('ACORALES')
+response
+```
+
+## Family
+
+To retrieve a list of all Families
+```
+response = client.taxa.family.list
+response
+```
+
+To retrieve a list of assessments for a given Family
+```
+response = client.taxa.family.all('ACANTHACEAE')
+response
+```
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/iucnredlistrb.rb
+++ b/lib/iucnredlistrb.rb
@@ -7,6 +7,7 @@ require "json"
 require_relative "iucnredlistrb/assessment"
 require_relative "iucnredlistrb/client"
 require_relative "iucnredlistrb/resource"
+require_relative "iucnredlistrb/taxa"
 require_relative "iucnredlistrb/version"
 
 module IUCNRedListRb

--- a/lib/iucnredlistrb/client.rb
+++ b/lib/iucnredlistrb/client.rb
@@ -30,6 +30,10 @@ module IUCNRedListRb
       @assessment ||= IUCNRedListRb::Assessment.new(self)
     end
 
+    def taxa
+      @taxa ||= IUCNRedListRb::Taxa.new(self)
+    end
+
     RESOURCE_NAMES.each do |resource_name|
       define_method(resource_name) do
         instance_variable_get("@#{resource_name}") ||

--- a/lib/iucnredlistrb/taxa.rb
+++ b/lib/iucnredlistrb/taxa.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module IUCNRedListRb
   class Taxa
     def initialize(client)
@@ -10,7 +12,7 @@ module IUCNRedListRb
       class
       order
       family
-    ]
+    ].freeze
 
     TAXA_LEVELS.each do |taxa_level|
       define_method(taxa_level) do

--- a/lib/iucnredlistrb/taxa.rb
+++ b/lib/iucnredlistrb/taxa.rb
@@ -1,0 +1,24 @@
+module IUCNRedListRb
+  class Taxa
+    def initialize(client)
+      @client = client
+    end
+
+    TAXA_LEVELS = %w[
+      kingdom
+      phylum
+      class
+      order
+      family
+    ]
+
+    TAXA_LEVELS.each do |taxa_level|
+      define_method(taxa_level) do
+        instance_variable_get("@#{taxa_level}") ||
+          instance_variable_set(
+            "@#{taxa_level}", IUCNRedListRb::Resource.new(@client, "taxa/#{taxa_level}")
+          )
+      end
+    end
+  end
+end

--- a/test/test_taxa.rb
+++ b/test/test_taxa.rb
@@ -1,0 +1,15 @@
+require "minitest/autorun"
+
+module IUCNRedListRb
+  class TaxaTest < Minitest::Test
+    def setup
+      @client = Client.new(api_key: "RED_LIST_API_KEY")
+    end
+
+    def test_taxa_levels_methods
+      Taxa::TAXA_LEVELS.each do |taxa_level|
+        assert_instance_of IUCNRedListRb::Resource, @client.taxa.send(taxa_level)
+      end
+    end
+  end
+end

--- a/test/test_taxa.rb
+++ b/test/test_taxa.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 
 module IUCNRedListRb


### PR DESCRIPTION
This PR adds a Taxa resource that can be used to retrieve data for a given taxa level e.g.

```
client = IUCNRedListRb::Client.new(api_key: 'YOUR_IUCN_RED_LIST_API_KEY')
# List all classes
client.taxa.class.list

# Return a list of all assessments for the AMPHIBIA class
client.taxa.class.all('AMPHIBIA', {}, show_progress: true)
```